### PR TITLE
Try to keep the previous log after a restart

### DIFF
--- a/src/main/kotlin/atm/bloodworkxgaming/serverstarter/LoaderManager.kt
+++ b/src/main/kotlin/atm/bloodworkxgaming/serverstarter/LoaderManager.kt
@@ -304,6 +304,10 @@ class LoaderManager(private val configFile: ConfigFile, private val internetMana
         if (logDirectory.exists()) {
             val latestLog = File(basepath + "logs/latest.log")
             if (latestLog.exists()) {
+                val previousLog = File(basepath + "logs/previous.log")
+                if (previousLog.exists()) {
+                    previousLog.delete();
+                }
                 latestLog.copyTo(File(basepath + "logs/previous.log"))
             }
         }

--- a/src/main/kotlin/atm/bloodworkxgaming/serverstarter/LoaderManager.kt
+++ b/src/main/kotlin/atm/bloodworkxgaming/serverstarter/LoaderManager.kt
@@ -298,8 +298,19 @@ class LoaderManager(private val configFile: ConfigFile, private val internetMana
         .replace("{{@mcversion@}}", lockFile.mcVersion)
         .replace("{{@os@}}", if (OSUtil.isWindows) "win" else "unix")
 
+    private fun tryToCopyLatestLogToPreviousLog() {
+        val basepath = configFile.install.baseInstallPath;
+        val logDirectory = File(basepath + "logs")
+        if (logDirectory.exists()) {
+            val latestLog = File(basepath + "logs/latest.log")
+            if (latestLog.exists()) {
+                latestLog.copyTo(File(basepath + "logs/previous.log"))
+            }
+        }
+    }
 
     private fun startAndWaitForProcess(args: List<String>) {
+        tryToCopyLatestLogToPreviousLog()
         ProcessBuilder(args).apply {
             inheritIO()
             directory(File(configFile.install.baseInstallPath + "."))

--- a/src/main/kotlin/atm/bloodworkxgaming/serverstarter/LoaderManager.kt
+++ b/src/main/kotlin/atm/bloodworkxgaming/serverstarter/LoaderManager.kt
@@ -299,18 +299,21 @@ class LoaderManager(private val configFile: ConfigFile, private val internetMana
         .replace("{{@os@}}", if (OSUtil.isWindows) "win" else "unix")
 
     private fun tryToCopyLatestLogToPreviousLog() {
-        val basepath = configFile.install.baseInstallPath;
+        val basepath = configFile.install.baseInstallPath
+
         val logDirectory = File(basepath + "logs")
-        if (logDirectory.exists()) {
-            val latestLog = File(basepath + "logs/latest.log")
-            if (latestLog.exists()) {
-                val previousLog = File(basepath + "logs/previous.log")
-                if (previousLog.exists()) {
-                    previousLog.delete();
-                }
-                latestLog.copyTo(File(basepath + "logs/previous.log"))
-            }
-        }
+        if (!logDirectory.exists())
+            return
+
+        val latestLog = File(basepath + "logs/latest.log")
+        if (!latestLog.exists())
+            return
+
+        val previousLog = File(basepath + "logs/previous.log")
+        if (previousLog.exists())
+            previousLog.delete()
+
+        latestLog.copyTo(previousLog)
     }
 
     private fun startAndWaitForProcess(args: List<String>) {


### PR DESCRIPTION
Just something i'm tinkering with, right before the minecraft instance (re)starts it'll try to keep the previous log aside.

Been running into some random crashes/reboots on my enigmatica 10 server and uncompressing the logs just to look at what happened seconds before is more effort than i'd like to put into it.

So yea i modified the starter to stash the latest.log as previous.log, i have yet to see in practice how well it works, unsure if i'll give the debug log the same treatment (main factor is what to call the file lol), putting this here as a WIP for ease of use.